### PR TITLE
BUG: Corrected index error after ceil function.

### DIFF
--- a/MeshStatistics/MeshStatistics.py
+++ b/MeshStatistics/MeshStatistics.py
@@ -414,7 +414,7 @@ class MeshStatisticsLogic(ScriptedLoadableModuleLogic):
         #  The lowest value is taken
         valueArray = numpy.sort(valueArray)
         index = (valueArray.size * percent) - 1
-        ceilIndex = math.ceil(index)
+        ceilIndex = int(math.ceil(index))
         return round(valueArray[ceilIndex], self.numberOfDecimals)
 
     def computeAll(self, fieldArray, fieldState, ROIArray):


### PR DESCRIPTION
Ceil function can return double number and so creating a bug as the result is used as an array index. Added a security.