### PR TITLE
FIX: Minimum height of results table too small

### DIFF
--- a/MeshStatistics/MeshStatistics.py
+++ b/MeshStatistics/MeshStatistics.py
@@ -285,7 +285,7 @@ class MeshStatisticsLogic(ScriptedLoadableModuleLogic):
         numberOfRows = fieldDictionaryValue.__len__()
         statTable.setRowCount(numberOfRows)
         i = numberOfRows - 1
-        statTable.setMinimumHeight(numberOfRows*35)
+        statTable.setMinimumHeight(0)  # fit to contents
         statTable.setMinimumWidth(55)
 
         statTable.setColumnCount(12)


### PR DESCRIPTION
If the Slicer window is too short, or too many panels are open on the
left widget, the results table is collapsed. This changes the minimum
size to auto-fit to contents of the table, so results will always be
visible.

Fixes #14